### PR TITLE
save_json: disallow NaN

### DIFF
--- a/evofr/posterior/posterior_helpers.py
+++ b/evofr/posterior/posterior_helpers.py
@@ -149,6 +149,8 @@ def get_growth_advantage(samples, data, ps, name, rel_to=None):
 
 class EvofrEncoder(json.JSONEncoder):
     def default(self, obj):
+        if isinstance(obj, np.nan):
+            return None
         if isinstance(obj, np.integer):
             return int(obj)
         if isinstance(obj, np.floating):

--- a/evofr/posterior/posterior_helpers.py
+++ b/evofr/posterior/posterior_helpers.py
@@ -448,5 +448,5 @@ def combine_sites_tidy(tidy_dicts):
 
 def save_json(out: dict, path) -> None:
     with open(path, "w") as f:
-        json.dump(out, f, cls=EvofrEncoder)
+        json.dump(out, f, allow_nan=False, cls=EvofrEncoder)
     return None


### PR DESCRIPTION
Do not allow NaN values in exported JSON to be compliant with JSON specifications. Prevents users from running into a SyntaxError when trying to load the JSON in a JavaScript app.

This will raise a ValueError if the provided output does contain nan, inf, or -inf values. These values should be handled upstream or within the `EvofrEncoder`.