### PR TITLE
Fix EvofrEncoder: check for nan with np.isnan

### DIFF
--- a/evofr/posterior/posterior_helpers.py
+++ b/evofr/posterior/posterior_helpers.py
@@ -149,7 +149,7 @@ def get_growth_advantage(samples, data, ps, name, rel_to=None):
 
 class EvofrEncoder(json.JSONEncoder):
     def default(self, obj):
-        if isinstance(obj, np.nan):
+        if np.isnan(obj):
             return None
         if isinstance(obj, np.integer):
             return int(obj)


### PR DESCRIPTION
np.nan is not a type so it will not work with `isinstance`. Use `np.isnan` to check for nan values instead.