### PR TITLE
Fix EvofrEncoder: remove `np.isnan` check

### DIFF
--- a/evofr/posterior/posterior_helpers.py
+++ b/evofr/posterior/posterior_helpers.py
@@ -149,8 +149,6 @@ def get_growth_advantage(samples, data, ps, name, rel_to=None):
 
 class EvofrEncoder(json.JSONEncoder):
     def default(self, obj):
-        if np.isnan(obj):
-            return None
         if isinstance(obj, np.integer):
             return int(obj)
         if isinstance(obj, np.floating):


### PR DESCRIPTION
This lead to a ValueError when the passed obj is an np.ndarray type.

I'm completely removing this check because this implementation would not work as expected in the first place. Since the JSON encoder knows how to serialize np.nan, the custom encoder's `default` method doesn't even get called! See detailed comments in #6.

Fixes #6, but does not resolve the possibility of `save_json` raising a ValueError if it runs into `np.nan` values in the output. 