### PR TITLE
Adding plotting classes for simplified analysis

### DIFF
--- a/evofr/plotting/__init__.py
+++ b/evofr/plotting/__init__.py
@@ -1,1 +1,2 @@
 from .plot_functions import *
+from .plotting_classes import *

--- a/evofr/plotting/plot_functions.py
+++ b/evofr/plotting/plot_functions.py
@@ -420,3 +420,32 @@ def plot_ppc_cases(
             t, V[i][0, :], V[i][1, :], color=color, alpha=alphas[i]
         )
     ax.plot(t, med, color=color)
+
+
+def plot_time_varying_variant(
+    ax,
+    site,
+    samples,
+    ps: List[float],
+    alphas: List[float],
+    colors: List[str],
+    forecast: Optional[bool] = False,
+):
+    t, med, quants = prep_posterior_for_plot(
+        site, samples, ps, forecast=forecast
+    )
+    plot_posterior_time(ax, t, med, quants, alphas, colors)
+
+
+def plot_time_varying_single(
+    ax, site, samples, ps: List[float], alphas: List[float], color: str
+):
+    med, V = get_quantiles(samples, ps, site)
+    t = jnp.arange(0, V[-1].shape[-1], 1)
+
+    # Make figure
+    for i in range(len(ps)):
+        ax.fill_between(
+            t, V[i][0, :], V[i][1, :], color=color, alpha=alphas[i]
+        )
+    ax.plot(t, med, color=color)

--- a/evofr/plotting/plot_functions.py
+++ b/evofr/plotting/plot_functions.py
@@ -102,11 +102,13 @@ def plot_R(
     alphas: List[float],
     colors: List[str],
     forecast: Optional[bool] = False,
+    plot_neutral_line: Optional[bool] = True,
 ):
     t, med, quants = prep_posterior_for_plot(
         "R", samples, ps, forecast=forecast
     )
-    ax.axhline(y=1.0, color="k", linestyle="--")
+    if plot_neutral_line:
+        ax.axhline(y=1.0, color="k", linestyle="--")
     plot_posterior_time(ax, t, med, quants, alphas, colors)
 
 
@@ -118,11 +120,13 @@ def plot_R_censored(
     colors: List[str],
     forecast: Optional[bool] = False,
     thres: Optional[float] = 0.001,
+    plot_neutral_line: Optional[bool] = True,
 ):
     t, med, quants = prep_posterior_for_plot(
         "R", samples, ps, forecast=forecast
     )
-    ax.axhline(y=1.0, color="k", linestyle="--")
+    if plot_neutral_line:
+        ax.axhline(y=1.0, color="k", linestyle="--")
 
     # Plot only variants at high enough frequency
     _, freq_median, _ = prep_posterior_for_plot(
@@ -134,13 +138,19 @@ def plot_R_censored(
 
 
 def plot_posterior_average_R(
-    ax, samples, ps: List[float], alphas: List[float], color: str
+    ax,
+    samples,
+    ps: List[float],
+    alphas: List[float],
+    color: str,
+    plot_neutral_line: Optional[bool] = True,
 ):
     med, V = get_quantiles(samples, ps, "R_ave")
     t = jnp.arange(0, V[-1].shape[-1], 1)
 
     # Make figure
-    ax.axhline(y=1.0, color="k", linestyle="--")
+    if plot_neutral_line:
+        ax.axhline(y=1.0, color="k", linestyle="--")
     for i in range(len(ps)):
         ax.fill_between(
             t, V[i][0, :], V[i][1, :], color=color, alpha=alphas[i]
@@ -156,11 +166,13 @@ def plot_little_r_censored(
     colors: List[str],
     forecast: Optional[bool] = False,
     thres: Optional[float] = 0.001,
+    plot_neutral_line: Optional[bool] = False,
 ):
     t, med, quants = prep_posterior_for_plot(
         "r", samples, ps, forecast=forecast
     )
-    ax.axhline(y=0.0, color="k", linestyle="--")
+    if plot_neutral_line:
+        ax.axhline(y=0.0, color="k", linestyle="--")
 
     # Plot only variants at high enough frequency
     _, freq_median, _ = prep_posterior_for_plot(
@@ -267,13 +279,21 @@ def add_dates_sep(ax, dates, sep=7):
 
 
 def plot_growth_advantage(
-    ax, samples, LD, ps: List[float], alphas: List[float], colors: List[str]
+    ax,
+    samples,
+    LD,
+    ps: List[float],
+    alphas: List[float],
+    colors: List[str],
+    plot_pivot_line: Optional[bool] = True,
 ):
     ga = jnp.array(samples["ga"])
 
     inds = jnp.arange(0, ga.shape[-1], 1)
 
-    ax.axhline(y=1.0, color="k", linestyle="--")
+    if plot_pivot_line:
+        ax.axhline(y=1.0, color="k", linestyle="--")
+
     parts = ax.violinplot(
         ga.T, inds, showmeans=False, showmedians=False, showextrema=False
     )
@@ -292,6 +312,32 @@ def plot_growth_advantage(
 
     ax.set_xticks(inds)
     ax.set_xticklabels(LD.var_names[:-1])
+
+
+def plot_ga_time_censored(
+    ax,
+    samples,
+    ps: List[float],
+    alphas: List[float],
+    colors: List[str],
+    forecast: Optional[bool] = False,
+    thres: Optional[float] = 0.001,
+    plot_pivot_line: Optional[bool] = True,
+):
+    t, med, quants = prep_posterior_for_plot(
+        "ga", samples, ps, forecast=forecast
+    )
+
+    if plot_pivot_line:
+        ax.axhline(y=1.0, color="k", linestyle="--")
+
+    # Plot only variants at high enough frequency
+    _, freq_median, _ = prep_posterior_for_plot(
+        "freq", samples, ps, forecast=forecast
+    )
+    included = freq_median > thres
+
+    plot_posterior_time(ax, t, med, quants, alphas, colors, included=included)
 
 
 def plot_total_by_obs_frequency(ax, LD, total, colors: List[str]):

--- a/evofr/plotting/plotting_classes.py
+++ b/evofr/plotting/plotting_classes.py
@@ -1,0 +1,268 @@
+from typing import Dict, Optional, Tuple
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+from evofr.data.data_helpers import expand_dates
+from evofr.data.data_spec import DataSpec
+from evofr.plotting.plot_functions import (
+    add_dates_sep,
+    plot_R_censored,
+    plot_cases,
+    plot_growth_advantage,
+    plot_observed_frequency,
+    plot_posterior_I,
+    plot_posterior_frequency,
+    plot_ppc_frequency,
+)
+
+from evofr.posterior.posterior_handler import PosteriorHandler
+
+
+DEFAULT_FIG_SIZE = (10, 6)
+DEFAULT_PS = [0.8]
+DEFAULT_ALPHAS = [0.4]
+
+
+def create_empty_gridspec(
+    nrows: int, ncols: int, figsize: Optional[Tuple] = None
+):
+    fig = plt.figure(
+        figsize=figsize if figsize is not None else DEFAULT_FIG_SIZE
+    )
+    gs = fig.add_gridspec(nrows=nrows, ncols=ncols)
+    return fig, gs
+
+
+def create_date_axis(ax, plot_dates, date_sep=None, forecast_L=0):
+    if forecast_L > 0:
+        plot_dates = expand_dates(plot_dates, forecast_L)
+        ax.axvline(
+            x=len(plot_dates) - 1, color="k", linestyle="--"
+        )  # Adding forecast cut off
+    sep = date_sep if date_sep is not None else 20
+    add_dates_sep(ax, plot_dates, sep=sep)  # Adding dates
+    return None
+
+
+class EvofrPlot:
+    def __init__(
+        self,
+        posterior: Optional[PosteriorHandler] = None,
+        samples: Optional[Dict] = None,
+        data: Optional[DataSpec] = None,
+    ):
+        if posterior is not None:
+            self.samples = posterior.samples
+            self.data = posterior.data
+        else:
+            self.samples = samples if samples is not None else dict()
+            self.data = data if data is not None else None
+
+
+class FrequencyPlot(EvofrPlot):
+    def __init__(
+        self,
+        posterior: Optional[PosteriorHandler] = None,
+        samples: Optional[Dict] = None,
+        data: Optional[DataSpec] = None,
+        color_map: Optional[dict] = None,
+    ):
+        super().__init__(posterior=posterior, samples=samples, data=data)
+        self.color_map = color_map if color_map is not None else dict()
+
+    def plot(
+        self,
+        ax=None,
+        figsize: Optional[Tuple] = None,
+        forecast: Optional[bool] = False,
+        date_sep: Optional[int] = None,
+        forecast_L: int = 0,
+        posterior: bool = True,
+        observed: bool = True,
+        predictive: bool = False,
+    ):
+        if ax is None:
+            # Create a figure and axis
+            fig, gs = create_empty_gridspec(1, 1, figsize=figsize)
+            ax = fig.add_subplot(gs[0])
+
+        colors = [
+            self.color_map[v] for v in self.data.var_names
+        ]  # Mapping colors to observed variants
+
+        # Plot predicted frequencies
+        if posterior:
+            plot_posterior_frequency(
+                ax,
+                self.samples,
+                DEFAULT_PS,
+                DEFAULT_ALPHAS,
+                colors,
+                forecast=forecast,
+            )
+
+        if predictive:
+            plot_ppc_frequency(
+                ax,
+                self.samples,
+                self.data,
+                DEFAULT_PS,
+                DEFAULT_ALPHAS,
+                colors,
+            )
+
+        if observed:
+            plot_observed_frequency(
+                ax, self.data, colors
+            )  # Plot observed frequencies
+
+        if hasattr(self.data, "dates"):
+            create_date_axis(ax, self.data.dates, date_sep, forecast_L)
+        ax.set_ylabel("Variant frequency")  # Making ylabel
+        return ax
+
+
+class GrowthAdvantagePlot(EvofrPlot):
+    def __init__(
+        self,
+        posterior: Optional[PosteriorHandler] = None,
+        samples: Optional[Dict] = None,
+        data: Optional[DataSpec] = None,
+        color_map: Optional[dict] = None,
+    ):
+        super().__init__(posterior=posterior, samples=samples, data=data)
+        self.color_map = color_map if color_map is not None else dict()
+
+    def plot(
+        self,
+        ax=None,
+        figsize: Optional[Tuple] = None,
+    ):
+        # TODO: Add support for time-varying growth advantages
+        if ax is None:
+            # Create a figure and axis
+            fig, gs = create_empty_gridspec(1, 1, figsize=figsize)
+            ax = fig.add_subplot(gs[0])
+
+        colors = [
+            self.color_map[v] for v in self.data.var_names
+        ]  # Mapping colors to observed variants
+
+        plot_growth_advantage(
+            ax, self.samples, self.data, DEFAULT_PS, DEFAULT_ALPHAS, colors
+        )
+        ax.set_ylabel("Growth advantage")
+        return ax
+
+
+class RtPlot(EvofrPlot):
+    def __init__(
+        self,
+        posterior: Optional[PosteriorHandler] = None,
+        samples: Optional[Dict] = None,
+        data: Optional[DataSpec] = None,
+        color_map: Optional[dict] = None,
+        thres: Optional[float] = None,
+    ):
+        super().__init__(posterior=posterior, samples=samples, data=data)
+        self.color_map = color_map if color_map is not None else dict()
+        self.thres = thres if thres is not None else 0.01
+
+    def plot(
+        self,
+        ax=None,
+        figsize: Optional[Tuple] = None,
+        date_sep: Optional[int] = None,
+    ):
+        # TODO: Add option to remove dashed line at 1.0
+        if ax is None:
+            # Create a figure and axis
+            fig, gs = create_empty_gridspec(1, 1, figsize=figsize)
+            ax = fig.add_subplot(gs[0])
+
+        colors = [
+            self.color_map[v] for v in self.data.var_names
+        ]  # Mapping colors to observed variants
+
+        plot_R_censored(
+            ax,
+            self.samples,
+            DEFAULT_PS,
+            DEFAULT_ALPHAS,
+            colors,
+            thres=0.001,
+        )
+        ax.set_ylabel("Effective Reproduction number")  # Making ylabel
+        if hasattr(self.data, "dates"):
+            create_date_axis(ax, self.data.dates, date_sep)
+
+        return ax
+
+
+class IncidencePlot(EvofrPlot):
+    def __init__(
+        self,
+        posterior: Optional[PosteriorHandler] = None,
+        samples: Optional[Dict] = None,
+        data: Optional[DataSpec] = None,
+        color_map: Optional[dict] = None,
+    ):
+        super().__init__(posterior=posterior, samples=samples, data=data)
+        self.color_map = color_map if color_map is not None else dict()
+
+    def plot(
+        self,
+        ax=None,
+        figsize: Optional[Tuple] = None,
+        cases: Optional[bool] = True,
+        date_sep: Optional[int] = None,
+    ):
+        if ax is None:
+            # Create a figure and axis
+            fig, gs = create_empty_gridspec(1, 1, figsize=figsize)
+            ax = fig.add_subplot(gs[0])
+
+        colors = [
+            self.color_map[v] for v in self.data.var_names
+        ]  # Mapping colors to observed variants
+
+        # Plot posterior variant specific incidence
+        plot_posterior_I(
+            ax,
+            self.samples,
+            DEFAULT_PS,
+            DEFAULT_ALPHAS,
+            colors,
+        )
+
+        if cases:
+            plot_cases(ax, self.data)
+        if hasattr(self.data, "dates"):
+            create_date_axis(ax, self.data.dates, date_sep)
+        return ax
+
+
+class PatchLegend:
+    def __init__(
+        self,
+        color_map: Dict,
+        ncol: Optional[int] = None,
+        loc: Optional[str] = None,
+    ):
+        self.color_map = color_map
+        self.ncol = ncol
+        self.loc = loc
+
+    def add_legend(self, fig=None, ax=None):
+        if fig is None and ax is not None:
+            fig = ax.get_figure()
+        patches = [
+            mpl.patches.Patch(color=color, label=label)
+            for label, color in self.color_map.items()
+        ]
+
+        ncol = len(self.color_map.keys()) if self.ncol is None else self.ncol
+        labels = list(self.color_map.keys())
+        legend = fig.legend(patches, labels, ncol=ncol, loc=self.loc)
+        legend.get_frame().set_linewidth(2.0)
+        legend.get_frame().set_edgecolor("k")
+        return fig


### PR DESCRIPTION
Taking a first pass at adding plotting class to reduce plotting boilerplate code.

This means that plotting variant frequencies can be as simple as:

### Simplest example 
```python
FrequencyPlot(posterior, color_map=color_map).plot()
```

![FrequencyPlot](https://user-images.githubusercontent.com/40400747/210912227-a9026c60-dd18-4e78-8f7b-dc7c4c8a6aec.png)

### More complicated example

You can also use these with a given figure axis to make more complicated plots by providing an axis.

An example using this

```python
fig = plt.figure(figsize=(16, 4.5))
gs = fig.add_gridspec(nrows=1, ncols=3)

ax_incidence = fig.add_subplot(gs[1])
ax_freq = fig.add_subplot(gs[0])
ax_rt = fig.add_subplot(gs[2])

FrequencyPlot(posterior, color_map=color_map).plot(ax=ax_freq, date_sep=30);
IncidencePlot(posterior, color_map=color_map).plot(ax=ax_incidence, date_sep=30);
RtPlot(posterior, color_map=color_map).plot(ax=ax_rt, date_sep=30);


fig = PatchLegend(color_map, loc="lower center").add_legend(ax_incidence.get_figure())
fig.subplots_adjust(bottom = 0.15)
```

![ComplexPlot](https://user-images.githubusercontent.com/40400747/210912318-2a2e6e5e-c4dc-4258-9962-5fc71b275069.png)

### Tasks to finish

There are a couple of tasks I'd like to complete before merging this:

- [x] Adding support for time-varying growth advantage
- [ ] General support for named time-varying sites and for single time-varying quantities e.g. Average Rt
- [x]  Removing the need to specify a color mapping ahead of time