### PR TITLE
Properly match generation times

### DIFF
--- a/evofr/models/renewal_model/model_factories.py
+++ b/evofr/models/renewal_model/model_factories.py
@@ -39,7 +39,7 @@ def _renewal_model(
         # Specifying variant name map to column
         if gen_v_names is not None:
             v_idx = [
-                var_names.index(s) for s in gen_v_names
+                gen_v_names.index(s) for s in var_names
             ]  # Match names in data to generation times
             _g_rev = _g_rev[v_idx, :]
 


### PR DESCRIPTION
Currently generation times are being improperly matches to variants present in the data for the renewal equation model, so that if you provide generation times for variants not present in your data it will provide errors.

This PR fixes this issue by searching through only variants present in the data.