### PR TITLE
`pivot` and `var_names` incompatible in `VariantFrequencies`

### DIFF
--- a/evofr/data/variant_frequencies.py
+++ b/evofr/data/variant_frequencies.py
@@ -80,16 +80,20 @@ class VariantFrequencies(DataSpec):
 
         var_names:
             optional list containing names of variants to be present.
+            The last of these variants is used as the pivot.
 
         pivot:
             optional name of variant to place last.
             Defaults to "other" if present otherwise.
             This will usually used as a reference or pivot strain.
+            Can only be used if you do not set `var_names`.
 
         Returns
         -------
         VariantFrequencies
         """
+        if (pivot is not None) and (var_name is not None):
+            raise ValueError("cannot set both pivot and var_name")
 
         # Get mapping from date to index
         if date_to_index is None:

--- a/evofr/data/variant_frequencies.py
+++ b/evofr/data/variant_frequencies.py
@@ -92,8 +92,8 @@ class VariantFrequencies(DataSpec):
         -------
         VariantFrequencies
         """
-        if (pivot is not None) and (var_name is not None):
-            raise ValueError("cannot set both pivot and var_name")
+        if (pivot is not None) and (var_names is not None):
+            raise ValueError("cannot set both pivot and var_names")
 
         # Get mapping from date to index
         if date_to_index is None:


### PR DESCRIPTION
Previously you could specify both `pivot` and `var_names` when instantiating `VariantFrequencies`. But if this was done, the value of `pivot` was silently ignored in favor of making the pivot variant the last name in `var_names`.

This pull request fixes this misleading behavior by making those parameters mutually exclusive, and raising an error if the user tries to set both.