### PR TITLE
Replace `KeyArray` with `jax.Array`

### DIFF
--- a/evofr/infer/MCMC_handler.py
+++ b/evofr/infer/MCMC_handler.py
@@ -1,8 +1,7 @@
 import pickle
 from typing import Callable, Dict, Optional, Type
 
-from jax import random
-from jax._src.random import KeyArray
+from jax import random, Array
 from numpyro.infer import MCMC, NUTS, Predictive
 from numpyro.infer.mcmc import MCMCKernel
 
@@ -10,7 +9,7 @@ from numpyro.infer.mcmc import MCMCKernel
 class MCMCHandler:
     def __init__(
         self,
-        rng_key: Optional[KeyArray] = None,
+        rng_key: Optional[Array] = None,
         kernel: Optional[Type[MCMCKernel]] = None,
         **kernel_kwargs
     ):

--- a/evofr/infer/SVI_handler.py
+++ b/evofr/infer/SVI_handler.py
@@ -2,8 +2,7 @@ import pickle
 from typing import Any, Callable, Optional
 
 import jax.example_libraries.optimizers as optimizers
-from jax import random
-from jax._src.random import KeyArray
+from jax import random, Array
 from numpyro.infer import SVI, Predictive, Trace_ELBO
 from numpyro.infer.autoguide import AutoGuide
 from numpyro.infer.svi import SVIState
@@ -14,7 +13,7 @@ Optimizer = Any
 class SVIHandler:
     def __init__(
         self,
-        rng_key: Optional[KeyArray] = None,
+        rng_key: Optional[Array] = None,
         loss: Optional[Trace_ELBO] = None,
         optimizer: Optional[Optimizer] = None,
     ):


### PR DESCRIPTION
The private internal alias `KeyArray` was removed from jax in v0.4.36.¹ This commit replaces the private type with the recommended public type `jax.Array`.²

¹ <https://github.com/jax-ml/jax/commit/fee272e550109e7409e8ae6e992bbde7bd1f1b90> 
² <https://jax.readthedocs.io/en/latest/_autosummary/jax.Array.html#jax.Array>

Resolves https://github.com/blab/evofr/issues/43