### PR TITLE
Replace private jax modules with public API 

### DIFF
--- a/evofr/models/mlr_hierarchical_gp.py
+++ b/evofr/models/mlr_hierarchical_gp.py
@@ -5,8 +5,7 @@ import jax.numpy as jnp
 import numpy as np
 import numpyro
 import numpyro.distributions as dist
-from jax import jit, vmap
-from jax._src.interpreters.batching import Array
+from jax import jit, vmap, Array
 from jax.nn import softmax
 from jax.scipy.special import gammaln
 from numpyro.infer.reparam import TransformReparam

--- a/evofr/models/mlr_hierarchical_time_varying.py
+++ b/evofr/models/mlr_hierarchical_time_varying.py
@@ -5,8 +5,7 @@ import jax.numpy as jnp
 import numpy as np
 import numpyro
 import numpyro.distributions as dist
-from jax import vmap
-from jax._src.interpreters.batching import Array
+from jax import vmap, Array
 from jax.nn import softmax
 from numpyro.infer.reparam import TransformReparam
 

--- a/evofr/models/mlr_innovation.py
+++ b/evofr/models/mlr_innovation.py
@@ -8,7 +8,7 @@ import numpyro
 import numpyro.distributions as dist
 import pandas as pd
 from jax import vmap
-from jax._src.nn.functions import softmax
+from jax.nn import softmax
 
 from evofr.data.data_helpers import prep_dates, prep_sequence_counts
 from evofr.data.data_spec import DataSpec

--- a/evofr/models/renewal_model/renewal_regression.py
+++ b/evofr/models/renewal_model/renewal_regression.py
@@ -5,7 +5,7 @@ import numpy as np
 import numpyro
 import numpyro.distributions as dist
 from jax import jit, lax
-from jax._src.nn.functions import softmax
+from jax.nn import softmax
 
 from evofr.models.model_spec import ModelSpec
 from evofr.models.renewal_model.basis_functions.basis_fns import BasisFunction


### PR DESCRIPTION
_Note: This PR is based on top of https://github.com/blab/evofr/pull/44_

Replacing type and function imported from a private jax modules with the
public API to avoid potential future breakages due to changes in the
private modules similar to https://github.com/blab/evofr/issues/43.

- `jax._src.interpreters.batching.Array` => `jax.Array`
- `jax._src.nn.functions.softmax` => `jax.nn.softmax`