### PR TITLE
Adding CLI for `prepare_data` and `run_models`

### DIFF
--- a/evofr/cli.py
+++ b/evofr/cli.py
@@ -1,0 +1,24 @@
+import argparse
+from evofr.commands.run_model import run_model
+
+
+def main():
+    parser = argparse.ArgumentParser(prog="evofr", description="Evolutionary forecasting CLI")
+    subparsers = parser.add_subparsers(dest="command")
+    # Run-model command
+    parser_model = subparsers.add_parser("run-model", help="Run an evofr model")
+    parser_model.add_argument("--config", required=True, help="Path to YAML configuration file")
+    parser_model.add_argument("--export-path", help="Optional export directory override")
+    parser_model.add_argument("--seq-path", help="Optional sequence data override")
+    parser_model.add_argument("--cases-path", help="Optional case data override")
+    parser_model.add_argument("--pivot", help="Optional variant pivot override")
+    parser_model.set_defaults(func=run_model)
+
+    args = parser.parse_args()
+    if args.command:
+        args.func(args)
+    else:
+        parser.print_help()
+
+if __name__ == "__main__":
+    main()

--- a/evofr/cli.py
+++ b/evofr/cli.py
@@ -1,14 +1,44 @@
 import argparse
+
+from evofr.commands.prepare_data import prepare_data
 from evofr.commands.run_model import run_model
 
 
 def main():
-    parser = argparse.ArgumentParser(prog="evofr", description="Evolutionary forecasting CLI")
+    parser = argparse.ArgumentParser(
+        prog="evofr", description="Evolutionary forecasting CLI"
+    )
     subparsers = parser.add_subparsers(dest="command")
+
+    # Prepare-data command
+    parser_prepare = subparsers.add_parser(
+        "prepare-data", help="Prepare case and variant data"
+    )
+    parser_prepare.add_argument(
+        "--config", required=True, help="Path to YAML configuration file"
+    )
+    parser_prepare.add_argument(
+        "--seq-counts", help="Optional override: input sequence counts TSV"
+    )
+    parser_prepare.add_argument(
+        "--cases", help="Optional override: input case counts TSV (optional)"
+    )
+    parser_prepare.add_argument(
+        "--output-seq-counts", help="Optional override: output sequence counts TSV"
+    )
+    parser_prepare.add_argument(
+        "--output-cases", help="Optional override: output case counts TSV (optional)"
+    )
+    parser_prepare.set_defaults(func=prepare_data)
+
     # Run-model command
     parser_model = subparsers.add_parser("run-model", help="Run an evofr model")
-    parser_model.add_argument("--config", required=True, help="Path to YAML configuration file")
-    parser_model.add_argument("--export-path", help="Optional export directory override")
+    parser_model.add_argument(
+        "--config", required=True, help="Path to YAML configuration file"
+    )
+    parser_model.add_argument(
+        "--export-path", help="Optional export directory override"
+    )
     parser_model.add_argument("--seq-path", help="Optional sequence data override")
     parser_model.add_argument("--cases-path", help="Optional case data override")
     parser_model.add_argument("--pivot", help="Optional variant pivot override")
@@ -19,6 +49,7 @@ def main():
         args.func(args)
     else:
         parser.print_help()
+
 
 if __name__ == "__main__":
     main()

--- a/evofr/commands/prepare_data.py
+++ b/evofr/commands/prepare_data.py
@@ -1,0 +1,116 @@
+import argparse
+import logging
+import os
+from datetime import datetime, timedelta
+
+import pandas as pd
+import yaml
+
+# Setup logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Default Data Types
+CASES_DTYPES = {"location": "string", "cases": "int64"}
+SEQ_COUNTS_DTYPES = {"location": "string", "clade": "string", "sequences": "int64"}
+DEFAULT_CUTOFF_DATE = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
+
+
+def load_data(file_path, dtype_map):
+    """Load a TSV file into a pandas DataFrame, or return None if file is missing."""
+    if file_path and os.path.exists(file_path):
+        return pd.read_csv(file_path, sep="\t", parse_dates=["date"], dtype=dtype_map)
+    return None
+
+
+def override_config_with_cli(config, args):
+    """Override YAML config values with CLI arguments if provided."""
+    for key, value in vars(args).items():
+        if value is not None:
+            config[key] = value
+    return config
+
+
+def prepare_data(args):
+    """Prepare case counts and sequence counts by subsetting, pruning, and collapsing variants."""
+
+    # Load YAML config
+    with open(args.config, "r") as f:
+        config = yaml.safe_load(f).get("prepare_data", {})
+
+    # Override with CLI arguments
+    config = override_config_with_cli(config, args)
+
+    # Convert max_date to datetime object
+    logger.info(f"Setting max date (inclusive) as {config['max_date']}.")
+    max_date = datetime.strptime(config["max_date"], "%Y-%m-%d")
+
+    # Determine min_date if provided
+    min_date = None
+    if "included_days" in config:
+        min_date = max_date - timedelta(days=(config["included_days"] - 1))
+        logger.info(f"Setting min date (inclusive) as {min_date.strftime('%Y-%m-%d')}.")
+
+    # Load sequence counts
+    seq_counts = load_data(config["seq_counts"], SEQ_COUNTS_DTYPES)
+    if seq_counts is None:
+        raise ValueError("Sequence counts file is required but missing.")
+
+    # Load and filter case counts (optional)
+    cases = load_data(config.get("cases"), CASES_DTYPES)
+    if cases is not None:
+        cases = cases[
+            (cases["date"] >= min_date if min_date else True)
+            & (cases["date"] <= max_date)
+        ]
+        if "output_cases" in config:
+            cases.to_csv(config["output_cases"], sep="\t", index=False)
+            logger.info(f"Processed case counts saved to {config['output_cases']}")
+
+    # Process sequence counts
+    seq_counts["variant"] = seq_counts["clade"]
+
+    # Handle clade collapsing
+    force_included_clades = set()
+    if "force_include_clades" in config:
+        for clade_mapping in config["force_include_clades"]:
+            clade, variant = clade_mapping.split("=")
+            seq_counts.loc[seq_counts["clade"] == clade, "variant"] = variant
+            force_included_clades.add(clade)
+
+    # Prune sequence counts for recent days
+    if "prune_seq_days" in config:
+        max_clade_date = max_date - timedelta(days=config["prune_seq_days"])
+        seq_counts = seq_counts[seq_counts["date"] <= max_clade_date]
+
+    # Save processed sequence counts
+    seq_counts.to_csv(config["output_seq_counts"], sep="\t", index=False)
+    logger.info(f"Processed sequence counts saved to {config['output_seq_counts']}")
+
+
+def main():
+    """CLI wrapper for prepare-data command."""
+    parser = argparse.ArgumentParser(
+        description="Prepare case and sequence count data for evofr models."
+    )
+    parser.add_argument(
+        "--config", required=True, help="Path to YAML configuration file"
+    )
+    parser.add_argument(
+        "--seq-counts", help="Optional override: input sequence counts TSV"
+    )
+    parser.add_argument(
+        "--cases", help="Optional override: input case counts TSV (optional)"
+    )
+    parser.add_argument(
+        "--output-seq-counts", help="Optional override: output sequence counts TSV"
+    )
+    parser.add_argument(
+        "--output-cases", help="Optional override: output case counts TSV (optional)"
+    )
+    args = parser.parse_args()
+    prepare_data(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/evofr/commands/registries.py
+++ b/evofr/commands/registries.py
@@ -1,0 +1,11 @@
+# evofr/registries.py
+INFERENCE_REGISTRY = {}
+PRIOR_REGISTRY = {}
+
+def register_inference(cls):
+    INFERENCE_REGISTRY[cls.__name__] = cls
+    return cls
+
+def register_prior(cls):
+    PRIOR_REGISTRY[cls.__name__] = cls
+    return cls

--- a/evofr/commands/run_model.py
+++ b/evofr/commands/run_model.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python
+import argparse
+import inspect
+import json
+import logging
+import os
+from datetime import date
+
+import pandas as pd
+import yaml
+
+import evofr as ef
+
+# Set up basic logging.
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Import registries 
+from evofr.commands.registries import INFERENCE_REGISTRY, PRIOR_REGISTRY
+# Import base classes that automatically register subclasses.
+from evofr.data.data_spec import \
+    DataSpec  # DataSpec.registry will be used for data.
+from evofr.models.model_spec import \
+    ModelSpec  # ModelSpec.registry will be used for models.
+
+
+# ----------------------------------------------------------------------------
+# Helper: Filter Constructor Arguments
+# ----------------------------------------------------------------------------
+def filter_constructor_args(cls, config_dict):
+    """
+    Uses introspection to return a dict of only those keys in config_dict that
+    match the parameters of cls.__init__.
+    """
+    sig = inspect.signature(cls.__init__)
+    valid_args = {}
+    for param in sig.parameters.values():
+        if param.name == "self":
+            continue
+        if param.name in config_dict:
+            valid_args[param.name] = config_dict[param.name]
+    return valid_args
+
+
+# ----------------------------------------------------------------------------
+# Recursive Instantiation Function
+# ----------------------------------------------------------------------------
+def instantiate_from_config(config):
+    """
+    Recursively instantiate a component from a configuration dictionary.
+    If a dict contains a "type" key, then:
+      - First, check ModelSpec.registry for a model,
+      - Next, check DataSpec.registry for a data class,
+      - Then check INFERENCE_REGISTRY and PRIOR_REGISTRY.
+    Otherwise, recurse into nested dicts/lists.
+    """
+    if isinstance(config, dict):
+        if "type" in config:
+            comp_type = config["type"]
+            config_copy = {
+                k: instantiate_from_config(v) for k, v in config.items() if k != "type"
+            }
+            cls = None
+            if comp_type in ModelSpec.registry:
+                cls = ModelSpec.registry[comp_type]
+            elif comp_type in DataSpec.registry:
+                cls = DataSpec.registry[comp_type]
+            elif comp_type in INFERENCE_REGISTRY:
+                cls = INFERENCE_REGISTRY[comp_type]
+            elif comp_type in PRIOR_REGISTRY:
+                cls = PRIOR_REGISTRY[comp_type]
+            else:
+                raise ValueError(
+                    f"Component type '{comp_type}' not found in any registry."
+                )
+            args = filter_constructor_args(cls, config_copy)
+            return cls(**args)
+        else:
+            return {k: instantiate_from_config(v) for k, v in config.items()}
+    elif isinstance(config, list):
+        return [instantiate_from_config(item) for item in config]
+    else:
+        return config
+
+
+# ----------------------------------------------------------------------------
+# Override Data File Paths
+# ----------------------------------------------------------------------------
+def override_generic_paths_in_config(config, cli_args):
+    """
+    Recursively process a configuration dictionary (for model or data),
+    loading any file paths for keys ending with '_path' and storing the loaded
+    DataFrame under a new key (with the '_path' suffix removed).
+
+    Parameters:
+      config (dict): A configuration dictionary (e.g. config["model"] or config["data"]).
+      cli_args: The command-line arguments namespace.
+
+    Returns:
+      dict: The updated configuration dictionary with file paths replaced by DataFrames.
+    """
+    if isinstance(config, dict):
+        new_config = {}
+        for key, value in config.items():
+            if isinstance(value, dict) or isinstance(value, list):
+                new_config[key] = override_generic_paths_in_config(value, cli_args)
+            elif isinstance(value, str) and key.endswith("_path"):
+                # Use CLI override if available, otherwise use the YAML value.
+                file_path = getattr(cli_args, key, None) or value
+                try:
+                    df = pd.read_csv(file_path, sep="\t")
+                    new_key = key[:-5]  # Remove the '_path' suffix.
+                    new_config[new_key] = df
+                except Exception as e:
+                    raise ValueError(f"Failed to load file for key '{key}' from {file_path}: {e}")
+            else:
+                new_config[key] = value
+        return new_config
+    elif isinstance(config, list):
+        return [override_generic_paths_in_config(item, cli_args) for item in config]
+    else:
+        return config
+
+
+# ----------------------------------------------------------------------------
+# run_model Function (Exported)
+# ----------------------------------------------------------------------------
+def run_model(args):
+    """
+    Run an evofr model using a YAML configuration and command-line data file overrides.
+
+    Steps:
+      1. Load the YAML configuration from args.config.
+      2. Validate that the config contains "model", "data", and "inference" sections.
+      3. Override any keys in the data config that include "_path" with CLI values.
+      4. Instantiate the model, data, and inference components via recursive instantiation.
+      5. Run inference (fit the model to the data).
+      6. Export results to JSON using the package's export functions.
+    """
+    # Load YAML configuration.
+    try:
+        with open(args.config, "r") as f:
+            config = yaml.safe_load(f)
+        logger.info(f"Loaded configuration from {args.config}.")
+    except Exception as e:
+        logger.error(f"Failed to load config: {e}")
+        raise
+
+    # Validate required sections.
+    for section in ["model", "data", "inference"]:
+        if section not in config:
+            raise ValueError(f"Configuration file must contain a '{section}' section.")
+
+    # Override file paths in the data config using command-line arguments.
+    config["model"] = override_generic_paths_in_config(config["model"], args)
+    config["data"] = override_generic_paths_in_config(config["data"], args)
+    print(config["model"])
+    if args.cases_path:
+        try:
+            config["data"]["cases_path"] = pd.read_csv(args.cases_path, sep="\t")
+            logger.info(f"Overrode cases_path with file {args.cases_path}.")
+        except Exception as e:
+            logger.error(f"Failed to load cases file from {args.cases_path}: {e}")
+            raise
+
+    # Instantiate components.
+    try:
+        model = instantiate_from_config(config["model"])
+        data = instantiate_from_config(config["data"])
+        inference = instantiate_from_config(config["inference"])
+        logger.info("Successfully instantiated components:")
+        logger.info(f"  Model: {model}")
+        logger.info(f"  Data: {data}")
+        logger.info(f"  Inference: {inference}")
+    except Exception as e:
+        logger.error(f"Component instantiation failed: {e}")
+        raise
+
+    # Run model fitting.
+    try:
+        posterior = inference.fit(model, data)
+        logger.info(f"Inference complete. Posterior: {posterior}")
+    except Exception as e:
+        logger.error(f"Inference failed: {e}")
+        raise
+
+    # Export results using the package's export functions.
+    if args.export_path:
+        os.makedirs(args.export_path, exist_ok=True)
+        try:
+            results = ef.posterior.combine_sites_tidy(posterior)
+            results["metadata"]["updated"] = pd.to_datetime(date.today()).isoformat()
+            ef.save_json(results, path=os.path.join(args.export_path, "results.json"))
+            logger.info(
+                f"Results exported to {os.path.join(args.export_path, 'results.json')}"
+            )
+        except Exception as e:
+            logger.error(f"Failed to export results: {e}")
+            raise
+
+
+# ----------------------------------------------------------------------------
+# For Direct Execution (Testing)
+# ----------------------------------------------------------------------------
+def _main():
+    parser = argparse.ArgumentParser(
+        description="Run an evofr model using a YAML configuration and command-line data file overrides."
+    )
+    parser.add_argument(
+        "--config", required=True, help="Path to YAML configuration file."
+    )
+    # Data file overrides: keys must include "_path".
+    parser.add_argument(
+        "--raw-seq-path", dest="raw_seq_path", help="Path to raw sequence TSV file."
+    )
+    parser.add_argument(
+        "--raw-variant-parents-path",
+        dest="raw_variant_parents_path",
+        help="Path to raw variant parents TSV file.",
+    )
+    parser.add_argument(
+        "--cases-path", help="Path to raw cases TSV file (if applicable)."
+    )
+    parser.add_argument("--export-path", help="Path to export JSON results.")
+    args = parser.parse_args()
+    run_model(args)
+
+
+if __name__ == "__main__":
+    _main()

--- a/evofr/commands/run_model.py
+++ b/evofr/commands/run_model.py
@@ -198,7 +198,6 @@ def run_model(args):
     # Override file paths in the data config using command-line arguments.
     config["model"] = override_generic_paths_in_config(config["model"], args)
     config["data"] = override_generic_paths_in_config(config["data"], args)
-    print(config["model"])
     if args.cases_path:
         try:
             config["data"]["cases_path"] = pd.read_csv(args.cases_path, sep="\t")

--- a/evofr/data/data_spec.py
+++ b/evofr/data/data_spec.py
@@ -3,18 +3,26 @@ from typing import Optional
 
 
 class DataSpec(ABC):
+    # Registry to hold all subclasses by their class name.
+    registry = {}
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        DataSpec.registry[cls.__name__] = cls
+
     @abstractmethod
     def make_data_dict(self, data: Optional[dict] = None) -> dict:
-        """Get arguments to be passed to numpyro models as a dictionary.
-
+        """
+        Get arguments to be passed to numpyro models as a dictionary.
+        
         Parameters
         ----------
         data:
-            optional dictionary to add arguments to.
-
+            Optional dictionary to add arguments to.
+        
         Returns
-        --------
-        data:
-            dictionary containing arguments.
+        -------
+        dict:
+            Dictionary containing arguments.
         """
         pass

--- a/evofr/infer/InferMCMC.py
+++ b/evofr/infer/InferMCMC.py
@@ -3,6 +3,7 @@ from typing import Optional, Type
 from numpyro.infer import NUTS
 from numpyro.infer.mcmc import MCMCKernel
 
+from evofr.commands.registries import register_inference
 from evofr.data.data_spec import DataSpec
 from evofr.models.model_spec import ModelSpec
 from evofr.posterior.posterior_handler import PosteriorHandler
@@ -74,6 +75,7 @@ class InferMCMC:
         return self.posterior
 
 
+@register_inference
 class InferNUTS(InferMCMC):
     def __init__(self, num_warmup: int, num_samples: int, **kernel_kwargs):
         super().__init__(num_warmup, num_samples, NUTS, **kernel_kwargs)

--- a/evofr/infer/InferMCMC.py
+++ b/evofr/infer/InferMCMC.py
@@ -5,6 +5,7 @@ from numpyro.infer.mcmc import MCMCKernel
 
 from evofr.commands.registries import register_inference
 from evofr.data.data_spec import DataSpec
+from evofr.infer.InferSVI import init_to_MAP
 from evofr.models.model_spec import ModelSpec
 from evofr.posterior.posterior_handler import PosteriorHandler
 
@@ -79,3 +80,22 @@ class InferMCMC:
 class InferNUTS(InferMCMC):
     def __init__(self, num_warmup: int, num_samples: int, **kernel_kwargs):
         super().__init__(num_warmup, num_samples, NUTS, **kernel_kwargs)
+
+
+@register_inference
+class InferNUTS_from_MAP:
+    def __init__(self, num_warmup, num_samples, iters, lr):
+        self.num_warmup = num_warmup
+        self.num_samples = num_samples
+        self.iters = iters
+        self.lr = lr
+
+    def fit(self, model, data, name=None):
+        init_strat, _ = init_to_MAP(model, data, iters=self.iters, lr=self.lr)
+        inference_method = InferNUTS(
+            num_warmup=self.num_warmup,
+            num_samples=self.num_samples,
+            init_strategy=init_strat,
+            dense_mass=True,
+        )
+        return inference_method.fit(model, data, name=name)

--- a/evofr/infer/InferSVI.py
+++ b/evofr/infer/InferSVI.py
@@ -2,9 +2,11 @@ from typing import Optional, Type
 
 import jax.numpy as jnp
 from numpyro.infer import init_to_value
-from numpyro.infer.autoguide import AutoDelta, AutoGuide, AutoMultivariateNormal
+from numpyro.infer.autoguide import (AutoDelta, AutoGuide,
+                                     AutoMultivariateNormal)
 from numpyro.optim import Adam
 
+from evofr.commands.registries import register_inference
 from evofr.data.data_spec import DataSpec
 from evofr.models.model_spec import ModelSpec
 from evofr.posterior.posterior_handler import PosteriorHandler
@@ -94,11 +96,12 @@ class InferSVI:
         return self.posterior
 
 
+@register_inference
 class InferMAP(InferSVI):
     def __init__(self, iters: int, lr: float, **handler_kwargs):
         super().__init__(iters, lr, 1, AutoDelta, **handler_kwargs)
 
-
+@register_inference
 class InferFullRank(InferSVI):
     def __init__(self, iters: int, lr: float, num_samples: int, **handler_kwargs):
         super().__init__(

--- a/evofr/models/mlr_innovation.py
+++ b/evofr/models/mlr_innovation.py
@@ -10,6 +10,7 @@ import pandas as pd
 from jax import vmap
 from jax._src.nn.functions import softmax
 
+from evofr.commands.registries import register_prior
 from evofr.data.data_helpers import prep_dates, prep_sequence_counts
 from evofr.data.data_spec import DataSpec
 from evofr.models.renewal_model.model_options import MultinomialSeq
@@ -27,6 +28,7 @@ class DeltaPriorModel(ABC):
         pass
 
 
+@register_prior
 class DeltaNormalPrior(DeltaPriorModel):
     def __init__(self, loc: Optional[float] = None, scale: Optional[float] = None):
         self.loc = loc
@@ -51,6 +53,7 @@ class DeltaNormalPrior(DeltaPriorModel):
         return raw_delta
 
 
+@register_prior
 class DeltaRegressionPrior(DeltaPriorModel):
     def __init__(self, features):
         """Construct a regression-based prior for relative fitness innovations.
@@ -267,7 +270,7 @@ def prep_clade_list(
     """
 
     # First check:
-    # SHould be able to reduce to a faster solve maybe?
+    # Should be able to reduce to a faster solve maybe?
     var_names = (
         list(raw_variant_parents.variant.unique()) if var_names is None else var_names
     )

--- a/evofr/models/model_spec.py
+++ b/evofr/models/model_spec.py
@@ -8,21 +8,18 @@ class ModelSpec(ABC):
     Classes which inherit from ModelSpec must have an attribute 'model_fn'
     which defines the function to be used for inference in numpyro.
     """
+    registry = {}
 
     model_fn: Callable
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        # Automatically register the subclass under its class name.
+        ModelSpec.registry[cls.__name__] = cls
 
     @abstractmethod
     def augment_data(self, data: dict) -> None:
         """
         Augments existing data for inference with model specific information.
-
-        Parameters
-        ----------
-        data:
-            dictionary which contains arguments to 'model_fn'
-
-        Returns
-        -------
-        None
         """
         pass

--- a/evofr/posterior/posterior_json.py
+++ b/evofr/posterior/posterior_json.py
@@ -1,0 +1,138 @@
+import datetime
+from typing import Dict, List, Optional
+
+import numpy as np
+
+from evofr.data import DataSpec
+
+
+def add_dataspec_attr(export_dict, data, attr, key=None):
+    """Add data specification attributes to dictionary."""
+    key = key if key else attr
+    if hasattr(data, attr):
+        export_dict[key] = getattr(data, attr)
+
+
+def get_quantiles(samples, ps, site):
+    """Retrieve quantiles and median."""
+    med = np.median(samples[site], axis=0)
+    quants = [
+        np.quantile(samples[site], [0.5 * (1 - p), 0.5 * (1 + p)], axis=0) for p in ps
+    ]
+    return med, quants
+
+
+def forecast_dates(dates, T_forecast: int):
+    """Generate dates of forecast given forecast interval of length 'T_forecast'."""
+    last_date = dates[-1]
+    return [last_date + datetime.timedelta(days=d + 1) for d in range(T_forecast)]
+
+
+def create_entry(template, variant, value, ps, entries):
+    """Append a new entry directly to the list to avoid intermediate copies."""
+    entries.append(
+        {
+            **template,
+            "variant": variant,
+            "value": np.around(value, decimals=3),
+            "ps": ps,
+        }
+    )
+
+
+def process_site(
+    entries,
+    samples,
+    ps,
+    site,
+    date_map,
+    variants,
+    location,
+    forecast_date_map=None,
+):
+    med, quants = get_quantiles(samples, ps, site)
+
+    for v, variant in enumerate(variants):
+        if v >= med.shape[1]:
+            continue
+        template = {"site": site, "variant": variant, "location": location}
+
+        relevant_date_map = (
+            forecast_date_map if forecast_date_map else (date_map if date_map else None)
+        )
+        if relevant_date_map:
+            for date, index in relevant_date_map.items():
+                template["date"] = date.strftime("%Y-%m-%d")
+                create_entry(template, variant, med[index, v], "median", entries)
+
+                for i, p in enumerate(ps):
+                    create_entry(
+                        template,
+                        variant,
+                        quants[i][0, index, v],
+                        f"HDI_{round(p * 100)}_lower",
+                        entries,
+                    )
+                    create_entry(
+                        template,
+                        variant,
+                        quants[i][1, index, v],
+                        f"HDI_{round(p * 100)}_upper",
+                        entries,
+                    )
+        else:
+            # Handle non-dated sites differently if needed
+            create_entry(template, variant, med[v], "median", entries)
+            for i, p in enumerate(ps):
+                create_entry(
+                    template,
+                    variant,
+                    quants[i][0, v],
+                    f"HDI_{round(p * 100)}_lower",
+                    entries,
+                )
+                create_entry(
+                    template,
+                    variant,
+                    quants[i][1, v],
+                    f"HDI_{round(p * 100)}_upper",
+                    entries,
+                )
+
+
+def get_sites_variants_tidy(samples, data, sites, dated, forecasts, ps, name=None):
+    """Generate tidy data and metadata for given sites and samples."""
+    # Initialize metadata and configure probability keys
+    ps_keys = (
+        ["median"]
+        + [f"HDI_{round(p * 100)}_upper" for p in ps]
+        + [f"HDI_{round(p * 100)}_lower" for p in ps]
+    )
+    metadata = {"ps": ps_keys, "sites": sites, "location": name}
+
+    add_dataspec_attr(metadata, data, "dates", "dates")
+    add_dataspec_attr(metadata, data, "var_names", "variants")
+
+    # Prepare entries and handle all cases
+    entries = []
+    date_map = data.date_to_index if dated else None
+
+    for site, is_dated, is_forecast in zip(sites, dated, forecasts):
+        forecast_date_map = None
+        if is_forecast and is_dated:
+            T = samples[site].shape[1]
+            forecasted_dates = forecast_dates(data.dates, T)
+            forecast_date_map = {d: i for (i, d) in enumerate(forecasted_dates)}
+            metadata["forecast_dates"] = forecasted_dates
+
+        process_site(
+            entries,
+            samples,
+            ps,
+            site,
+            date_map if is_dated else None,
+            metadata["variants"],
+            name,
+            forecast_date_map if is_forecast else None,
+        )
+    return {"metadata": metadata, "data": entries}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,9 @@ description = "Tools for evolutionary forecasting."
 authors = ["marlinfiggins <marlinfiggins@gmail.com>"]
 license = "AGPL-3.0"
 
+[tool.poetry.scripts]
+evofr = "evofr.cli:main"
+
 [tool.poetry.dependencies]
 python = "^3.9"
 numpy = "^1.22.4"

--- a/test/configs/prepare_data.yaml
+++ b/test/configs/prepare_data.yaml
@@ -1,0 +1,12 @@
+prepare_data:
+  seq_counts: "test/data/raw_sequences.tsv"
+  cases: "test/data/raw_cases.tsv"   # Optional; can be omitted if cases not needed
+  output_seq_counts: "test/data/processed_sequences.tsv"
+  output_cases: "test/data/processed_cases.tsv"  # Optional; only if cases are provided
+  max_date: "2022-04-10"
+  included_days: 100
+  prune_seq_days: 7
+  location_min_seq: 1
+  location_min_seq_days: 100
+  clade_min_seq: 1
+  clade_min_seq_days: 100

--- a/test/configs/run_model.yaml
+++ b/test/configs/run_model.yaml
@@ -1,0 +1,16 @@
+model:
+  type: "MultinomialLogisticRegression"
+  tau: 4.2
+data:
+  type: "VariantFrequencies"
+  raw_seq_path: "test/data/processed_sequences_test.tsv"
+  pivot: "C"
+inference:
+  type: "InferNUTS"
+  num_warmup: 10
+  num_samples: 10
+export:
+  export_path: "test/output/results"
+  sites: ["freq", "ga"]
+  dated: [True, False]
+  forecasts: [False, False]

--- a/test/configs/run_model.yaml
+++ b/test/configs/run_model.yaml
@@ -6,9 +6,9 @@ data:
   raw_seq_path: "test/data/processed_sequences_test.tsv"
   pivot: "C"
 inference:
-  type: "InferNUTS"
-  num_warmup: 10
-  num_samples: 10
+  type: "InferMAP"
+  iters: 1000
+  lr: 0.0004
 export:
   export_path: "test/output/results"
   sites: ["freq", "ga"]

--- a/test/generate_cli_test_data.py
+++ b/test/generate_cli_test_data.py
@@ -65,7 +65,7 @@ def expand_seq_counts(df, location="TestCity"):
 
 
 def generate_test_data():
-    os.makedirs("data", exist_ok=True)
+    os.makedirs("test/data", exist_ok=True)
 
     # --- Simulate Sequence Counts ---
     deltas = np.array([1.1, 1.8, 1.0])
@@ -76,13 +76,13 @@ def generate_test_data():
     _, var_counts = simulate_MLR(deltas, freq0, tau=4.2, Ns=Ns)
     seq_counts = variant_counts_to_dataframe(var_counts, var_names=["A", "B", "C"])
     seq_counts["clade"] = seq_counts["variant"]
-    seq_counts.to_csv("data/processed_sequences_test.tsv", sep="\t", index=False)
+    seq_counts.to_csv("test/data/processed_sequences_test.tsv", sep="\t", index=False)
     print("Saved test/data/processed_sequences_test.tsv")
 
     # Expand to strain-level metadata
     # raw_sequences = expand_seq_counts(seq_counts, location="TestCity")
     # Save as tests/data/raw_sequences.tsv (note: no "_expanded" suffix)
-    seq_counts.to_csv("data/raw_sequences.tsv", sep="\t", index=False)
+    seq_counts.to_csv("test/data/raw_sequences.tsv", sep="\t", index=False)
     print("Saved test/data/raw_sequences.tsv")
 
     # --- Simulate Case Counts ---
@@ -90,7 +90,7 @@ def generate_test_data():
     np.random.seed(42)
     cases = np.random.poisson(lam=400, size=len(dates))
     cases_df = pd.DataFrame({"location": "TestCity", "date": dates, "cases": cases})
-    cases_df.to_csv("data/raw_cases.tsv", sep="\t", index=False)
+    cases_df.to_csv("test/data/raw_cases.tsv", sep="\t", index=False)
     print("Saved test/data/raw_cases.tsv")
 
 

--- a/test/generate_cli_test_data.py
+++ b/test/generate_cli_test_data.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+import os
+
+import numpy as np
+import pandas as pd
+
+
+def simulate_MLR_freq(growth_advantage, freq0, tau, max_time):
+    """Simulate variant frequencies over time."""
+    times = np.arange(max_time)
+    delta = np.log(growth_advantage) / tau
+    ufreq = freq0 * np.exp(delta * times[:, None])
+    return ufreq / ufreq.sum(axis=-1)[:, None]
+
+
+def simulate_MLR(growth_advantage, freq0, tau, Ns):
+    """Simulate sequence counts using multinomial draws."""
+    max_time = len(Ns)
+    freq = simulate_MLR_freq(growth_advantage, freq0, tau, max_time)
+    seq_counts = [
+        np.random.multinomial(int(Ns[t]), freq[t, :]) for t in range(max_time)
+    ]
+    return freq, np.stack(seq_counts)
+
+
+def variant_counts_to_dataframe(
+    var_counts, var_names, start_date=pd.to_datetime("2022-01-01")
+):
+    """
+    Convert a matrix of variant counts to a tidy DataFrame.
+    Only rows with positive counts are kept.
+    """
+    T, V = var_counts.shape
+    sequences, variants, dates = [], [], []
+    for t in range(T):
+        sequences.extend(list(var_counts[t, :]))
+        variants.extend(var_names[:V])
+        dates.extend([start_date + pd.Timedelta(days=t)] * V)
+    df = pd.DataFrame(
+        {
+            "variant": variants,
+            "sequences": sequences,
+            "date": dates,
+        }
+    )
+    return df[df.sequences > 0].reset_index(drop=True)
+
+
+def expand_seq_counts(df, location="TestCity"):
+    """
+    Expand aggregated sequence counts into strain-level metadata.
+
+    For each row in the aggregated DataFrame, repeat it 'sequences' times.
+    Add a 'location' column (if not present) and rename 'variant' to 'clade'.
+    The output DataFrame has columns: location, clade, date.
+    """
+    df = df.copy()
+    if "location" not in df.columns:
+        df["location"] = location
+    expanded = df.loc[df.index.repeat(df["sequences"])].reset_index(drop=True)
+    expanded = expanded.drop(columns=["sequences"])
+    expanded = expanded.rename(columns={"variant": "clade"})
+    expanded = expanded[["location", "clade", "date"]]
+    return expanded
+
+
+def generate_test_data():
+    os.makedirs("data", exist_ok=True)
+
+    # --- Simulate Sequence Counts ---
+    deltas = np.array([1.1, 1.8, 1.0])
+    freq0 = np.array([4e-2, 1e-5, 0.999])
+    freq0 = freq0 / freq0.sum()
+    Ns = 50 * np.ones(100)  # 100 days
+
+    _, var_counts = simulate_MLR(deltas, freq0, tau=4.2, Ns=Ns)
+    seq_counts = variant_counts_to_dataframe(var_counts, var_names=["A", "B", "C"])
+    seq_counts["clade"] = seq_counts["variant"]
+    seq_counts.to_csv("data/processed_sequences_test.tsv", sep="\t", index=False)
+    print("Saved test/data/processed_sequences_test.tsv")
+
+    # Expand to strain-level metadata
+    # raw_sequences = expand_seq_counts(seq_counts, location="TestCity")
+    # Save as tests/data/raw_sequences.tsv (note: no "_expanded" suffix)
+    seq_counts.to_csv("data/raw_sequences.tsv", sep="\t", index=False)
+    print("Saved test/data/raw_sequences.tsv")
+
+    # --- Simulate Case Counts ---
+    dates = pd.date_range(start="2022-01-01", periods=100, freq="D")
+    np.random.seed(42)
+    cases = np.random.poisson(lam=400, size=len(dates))
+    cases_df = pd.DataFrame({"location": "TestCity", "date": dates, "cases": cases})
+    cases_df.to_csv("data/raw_cases.tsv", sep="\t", index=False)
+    print("Saved test/data/raw_cases.tsv")
+
+
+if __name__ == "__main__":
+    generate_test_data()

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -16,7 +16,7 @@ def generate_test_data():
     raw_seq_file = TEST_DATA_DIR / "raw_sequences.tsv"
     raw_cases_file = TEST_DATA_DIR / "raw_cases.tsv"
     if not raw_seq_file.exists() or not raw_cases_file.exists():
-        subprocess.run("python generate_cli_test_data.py", shell=True, check=True)
+        subprocess.run("python test/generate_cli_test_data.py", shell=True, check=True)
     # Clean output directory.
     if TEST_OUTPUT_DIR.exists():
         shutil.rmtree(TEST_OUTPUT_DIR)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,0 +1,60 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+TEST_CONFIG_DIR = Path("test/configs")
+TEST_DATA_DIR = Path("test/data")
+TEST_OUTPUT_DIR = Path("test/output")
+CLI_COMMAND = "poetry run evofr"  # Adjust if necessary
+
+
+@pytest.fixture(scope="session", autouse=True)
+def generate_test_data():
+    """Ensure test data exists by running generate_test_data.py if needed."""
+    raw_seq_file = TEST_DATA_DIR / "raw_sequences.tsv"
+    raw_cases_file = TEST_DATA_DIR / "raw_cases.tsv"
+    if not raw_seq_file.exists() or not raw_cases_file.exists():
+        subprocess.run("python generate_cli_test_data.py", shell=True, check=True)
+    # Clean output directory.
+    if TEST_OUTPUT_DIR.exists():
+        shutil.rmtree(TEST_OUTPUT_DIR)
+    TEST_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def run_cli(command, expected_code=0):
+    result = subprocess.run(command, shell=True, capture_output=True, text=True)
+    assert result.returncode == expected_code, f"Command failed: {result.stderr}"
+    return result.stdout, result.stderr
+
+
+# --- Tests for prepare-data command ---
+def test_prepare_data_creates_output_files():
+    """Test that prepare-data produces expected output files."""
+    config_path = TEST_CONFIG_DIR / "prepare_data.yaml"
+    command = f"{CLI_COMMAND} prepare-data --config {config_path}"
+    run_cli(command)
+    seq_out = TEST_DATA_DIR / "processed_sequences.tsv"
+    # Check cases output only if config contains 'cases' key
+    config_text = config_path.read_text()
+    if (
+        "cases:" in config_text
+        and config_text.strip().split("cases:")[1].strip() != '""'
+    ):
+        cases_out = TEST_DATA_DIR / "processed_cases.tsv"
+        assert cases_out.exists(), "Case output file not created."
+    assert seq_out.exists(), "Sequence output file not created."
+
+
+# --- Tests for run-model command ---
+def test_run_model_creates_results():
+    """Test that run-model produces a results JSON file."""
+    config_path = TEST_CONFIG_DIR / "run_model.yaml"
+    export_dir = TEST_OUTPUT_DIR / "results"
+    command = (
+        f"{CLI_COMMAND} run-model --config {config_path} --export-path {export_dir}"
+    )
+    run_cli(command)
+    result_file = export_dir / "results.json"
+    assert result_file.exists(), "Results JSON file not created."


### PR DESCRIPTION
Following up on #48 and #49, I'm adding a CLI interface for these two purposes.

## Overview

This PR introduces a standardized command-line interface (CLI) for running evofr models, eliminating the need for per-project run-model.py scripts. The new CLI allows users to specify model configurations, data inputs, and inference settings via a YAML configuration file while also supporting command-line file overrides for input data.

## Challenge

The biggest challenge for this CLI is that the required inputs vary across data classes, models, and inference methods. Some models require priors (e.g., `InnovationMLR`), others need different types of sequence count data (e.g., `VariantFrequencies` vs. `InnovationSequenceCounts`), and inference methods have different parameter requirements (e.g., `InferNUTS` vs. `InferMAP`). We dynamically parses the configuration, identifies the appropriate components, and instantiates them with the correct arguments while allowing users to override file-based inputs at runtime.

## Solution
The CLI is implemented within evofr/commands/run_model.py and follows these steps:

- Configuration Loading: Reads a YAML file containing "model", "data", and "inference" sections.
- Data File Handling: Paths to data files (e.g., raw_seq_path) in the YAML can be overridden via CLI arguments (--raw-seq-path). The CLI automatically loads these files into pandas DataFrames before passing them to data classes.
- Component Instantiation: Uses a recursive function to identify and instantiate models, data classes, priors, and inference methods based on the YAML specification.
- Model Execution: Runs the specified inference method on the model and data.
- Results Export: Saves the fitted model results in JSON format to the specified output directory.

## Remaining challenges
- [ ] Adding forecasting logic
- [x] We still need to filter the data set to locations of interest before passing to the model config or CLI.
- [x] We need to scope out the what we want to prepare data command to do fully.

## Usage instructions
For testing purposes, you can run `poetry shell` and then use the commands below.

To use a config file, just run:
```bash
evofr run-model --config config.yaml
```

If you want to override input files at runtime

```bash
evofr run-model --config config.yaml \
    --raw-seq-path data/new_seq.tsv \
    --export-path results/
```

```
### Example config

```yaml
model:
  type: "MultinomialLogisticRegression"
  tau: 4.2
data:
  type: "VariantFrequencies"
  raw_seq_path: "test/testing_data/mlr-variant-counts.tsv"
  pivot: "C"
inference:
  type: "InferNUTS"
  num_warmup: 500
  num_samples: 1500
export:
  export_path: "results/"
  sites: ["freq", "ga"]
  dated: [True, False]
  forecasts: [False, False]
```
