### PR TITLE
Infer date interval for forecast dates

### DIFF
--- a/evofr/data/data_helpers.py
+++ b/evofr/data/data_helpers.py
@@ -34,9 +34,17 @@ def prep_dates(raw_dates: pd.Series):
 def forecast_dates(dates, T_forecast: int):
     """Generate dates of forecast given forecast interval of length 'T_forecast'."""
     last_date = dates[-1]
+
+    # Calculate the interval between input dates in days.
+    # Dates are expected to be pandas datetime instances.
+    if len(dates) > 1:
+        date_interval = (dates[-1] - dates[-2]).days
+    else:
+        date_interval = 1
+
     dates_f = []
-    for d in range(T_forecast):
-        dates_f.append(last_date + datetime.timedelta(days=d + 1))
+    for d in range(1, T_forecast + 1):
+        dates_f.append(last_date + datetime.timedelta(days=(d * date_interval)))
     return dates_f
 
 

--- a/test/data/test_data_helpers.py
+++ b/test/data/test_data_helpers.py
@@ -1,0 +1,24 @@
+import pandas as pd
+
+from evofr.data.data_helpers import forecast_dates
+
+
+def test_forecast_dates():
+    """The interval in days between forecast dates should reflect the interval
+    between the input dates.
+
+    """
+    # In this first example, we use daily inputs.
+    dates = [pd.to_datetime(date) for date in ["2020-01-01", "2020-01-02"]]
+    future_dates = [date.strftime("%Y-%m-%d") for date in forecast_dates(dates, 1)]
+    assert future_dates == ['2020-01-03']
+
+    # In the next example, we use inputs separated by 14 days.
+    dates = [pd.to_datetime(date) for date in ["2020-01-01", "2020-01-15"]]
+    future_dates = [date.strftime("%Y-%m-%d") for date in forecast_dates(dates, 1)]
+    assert future_dates == ['2020-01-29']
+
+    # When only a single input date is given, we have to assume an interval of 1 day.
+    dates = [pd.to_datetime(date) for date in ["2020-01-15"]]
+    future_dates = [date.strftime("%Y-%m-%d") for date in forecast_dates(dates, 1)]
+    assert future_dates == ['2020-01-16']


### PR DESCRIPTION
Instead of assuming that forecasts should be produced at daily intervals, inspect the interval between the given input dates and use that interval to generate forecasts. This commit adds doctests for expected behavior and then implements that behavior.

Note this fix only works when the input dates use a fixed size interval in units of days. If the interval between dates is variable (e.g., monthly), then forecasts will be based on the interval between the last two dates in the given input.