### PR TITLE
Add pyyaml as an explicit dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ numpyro = "^0.13.2"
 blackjax = "^0.9.6"
 matplotlib = "^3.9"
 seaborn = "^0.13.2"
+pyyaml = "^5 || ^6"
 
 [tool.poetry.group.dev.dependencies]
 jupyter = "^1.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,11 +19,9 @@ blackjax = "^0.9.6"
 matplotlib = "^3.9"
 seaborn = "^0.13.2"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 jupyter = "^1.0.0"
 pytest = "^7.1.2"
-
-[tool.poetry.group.dev.dependencies]
 black = "^24.4.2"
 pylint = "^3.1.0"
 wrapt = "^1.16.0"


### PR DESCRIPTION
Using >=5.3 based on the requirements of pyyaml as a transitive dependency.

```
$ poetry show pyyaml --why --tree
The "poetry.dev-dependencies" section is deprecated and will be removed in a future version. Use "poetry.group.dev.dependencies" instead.
jupyter-events 0.12.0 Jupyter Event System library
└── pyyaml >=5.3
pre-commit 3.8.0 A framework for managing and maintaining multi-language pre-commit hooks.
└── pyyaml >=5.1
```

Resolves https://github.com/blab/evofr/issues/58